### PR TITLE
Fix modal presentation + iOS 15+ bar tint issue

### DIFF
--- a/PWCoreSDK.podspec
+++ b/PWCoreSDK.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name         = "PWCoreSDK"
-  s.version      = "3.1.1"
+  s.version      = "3.1.2"
   s.summary      = "PWCoreSDK"
   s.description  = "Unified SDK for all paymentwall products on iOS"
   s.homepage     = "http://paymentwall.com"

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -15,10 +15,10 @@ PODS:
     - PWCoreSDK (>= 3.0.0)
   - PWMyCardPlugin (3.0.0):
     - PWCoreSDK (>= 3.0.0)
-  - PWWechatpayPlugin (3.0.1):
+  - PWWechatpayPlugin (3.1.1):
     - PWCoreSDK (>= 3.0.0)
-    - PWWechatpayPlugin/Wechatpay (= 3.0.1)
-  - PWWechatpayPlugin/Wechatpay (3.0.1):
+    - PWWechatpayPlugin/Wechatpay (= 3.1.1)
+  - PWWechatpayPlugin/Wechatpay (3.1.1):
     - PWCoreSDK (>= 3.0.0)
 
 DEPENDENCIES:
@@ -55,8 +55,8 @@ SPEC CHECKSUMS:
   PWCoreSDK: f4957795273e12a886ab01e5aa07f67cce305c9d
   PWGameUIPlugin: 94cb50a2f9e3ff698008c8b314e36d805290a393
   PWMyCardPlugin: e9960d1b874204f1e87194eaa48530def33d1725
-  PWWechatpayPlugin: 8f4e38c763877983f84710336b38af70455b39bb
+  PWWechatpayPlugin: 04ba61b9850fa9d38eda91b88d2c9a28276c725d
 
 PODFILE CHECKSUM: a586364a0697ab5d6f69699db3127c43ff75867b
 
-COCOAPODS: 1.8.4
+COCOAPODS: 1.11.3

--- a/pw-ios-sdk-demo.xcodeproj/project.pbxproj
+++ b/pw-ios-sdk-demo.xcodeproj/project.pbxproj
@@ -128,6 +128,7 @@
 				TargetAttributes = {
 					9CCFE4661ECE9CF5005627E0 = {
 						CreatedOnToolsVersion = 8.3.2;
+						DevelopmentTeam = 37N222R38X;
 						LastSwiftMigration = 0930;
 						ProvisioningStyle = Automatic;
 					};
@@ -371,7 +372,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 37N222R38X;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "pw-ios-sdk-demo/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -390,7 +391,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 37N222R38X;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "pw-ios-sdk-demo/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/pw-ios-sdk-demo/AppDelegate.swift
+++ b/pw-ios-sdk-demo/AppDelegate.swift
@@ -16,7 +16,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
-        //Fix Nav Bar tint issue in iOS 15.0 or later - is transparent w/o code below
+        //Fix Nav Bar tint issue in iOS 15.0 or later
         if #available(iOS 15, *) {
             let appearance = UINavigationBarAppearance()
             appearance.configureWithOpaqueBackground()

--- a/pw-ios-sdk-demo/AppDelegate.swift
+++ b/pw-ios-sdk-demo/AppDelegate.swift
@@ -16,6 +16,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
+        //Fix Nav Bar tint issue in iOS 15.0 or later - is transparent w/o code below
+        if #available(iOS 15, *) {
+            let appearance = UINavigationBarAppearance()
+            appearance.configureWithOpaqueBackground()
+            appearance.backgroundColor = UIColor.systemYellow
+            UINavigationBar.appearance().standardAppearance = appearance
+            UINavigationBar.appearance().scrollEdgeAppearance = appearance
+        }
+        
         return true
     }
     

--- a/pw-ios-sdk-demo/ViewController.swift
+++ b/pw-ios-sdk-demo/ViewController.swift
@@ -71,8 +71,8 @@ class ViewController: UIViewController {
     func setupPaymentwall() {
         self.setupUI()
         
-        PWCoreSDK.sharedInstance().setGlobalProjectKey("YOUR_PUBLIC_KEY")
-        PWCoreSDK.sharedInstance().setGlobalSecretKey("YOUR_SECRET_KEY")
+        PWCoreSDK.sharedInstance().setGlobalProjectKey("b1cae8467f36c08ee295c5c2ab65a384")
+        PWCoreSDK.sharedInstance().setGlobalSecretKey("545f683307fb303041c049e975a76dd7")
         
         brick = PWOptionBrick()
         brick.setCardScannerPlugin(PWCardScannerPlugin())


### PR DESCRIPTION
- Fix modal presentation when show payment screen. The user can't swipe down to dismiss the payment screen now.
- Fix the Navigation Bar tint issue in iOS 15.0 or later